### PR TITLE
Improves the modal behaviour

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -10,20 +10,6 @@ module.exports = {
     globals: {
         axios: true,
     },
-    settings: {
-        'import/resolver': {
-            alias: {
-                map: [
-                    ['@core', `${__dirname}/client/node_modules/@enso-ui/ui/src`],
-                    ['@root', `${__dirname}/client/src/js`],
-                    ['@pages', `${__dirname}/client/src/js/pages`],
-                    ['@store', `${__dirname}/client/src/js/store`],
-                    ['@components', `${__dirname}/client/src/js/components`],
-                    ['@calendar', `${__dirname}/client/node_modules/@enso-ui/calendar/src/bulma`],
-                ],
-            },
-        },
-    },
     parserOptions: {
         parser: 'babel-eslint',
         sourceType: 'module',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,44 +1,58 @@
 module.exports = {
-    'root': true,
+    root: true,
     extends: [
         'airbnb-base',
-        'plugin:vue/recommended'
+        'plugin:vue/recommended',
     ],
     plugins: [
         'vue',
     ],
     globals: {
         axios: true,
-        route: true,
+    },
+    settings: {
+        'import/resolver': {
+            alias: {
+                map: [
+                    ['@core', `${__dirname}/client/node_modules/@enso-ui/ui/src`],
+                    ['@root', `${__dirname}/client/src/js`],
+                    ['@pages', `${__dirname}/client/src/js/pages`],
+                    ['@store', `${__dirname}/client/src/js/store`],
+                    ['@components', `${__dirname}/client/src/js/components`],
+                    ['@calendar', `${__dirname}/client/node_modules/@enso-ui/calendar/src/bulma`],
+                ],
+            },
+        },
     },
     parserOptions: {
         parser: 'babel-eslint',
         sourceType: 'module',
-        'ecmaVersion': 2017,
-        allowImportExportEverywhere: true
+        ecmaVersion: 2017,
+        allowImportExportEverywhere: true,
     },
     rules: {
         'no-console': process.env.NODE_ENV === 'production' ? 'error' : 'off',
         'no-debugger': process.env.NODE_ENV === 'production' ? 'error' : 'off',
         indent: ['error', 4],
+        'arrow-parens': ["error", "as-needed"],
         'vue/html-indent': 0,
         'vue/attributes-order': 0,
         'no-plusplus': 0,
-        'no-debugger': 0,
         'no-param-reassign': 0,
         'no-mixed-operators': 0,
+        'no-underscore-dangle': 0,
         'func-names': 0,
         'no-shadow': 0,
         'vue/max-attributes-per-line': 0,
         'no-return-assign': ['error', 'except-parens'],
         'vue/html-closing-bracket-newline': ['error', {
-            'singleline': 'never',
-            'multiline': 'never'
+            singleline: 'never',
+            multiline: 'never',
         }],
         'vue/html-closing-bracket-spacing': ['error', {
-            'startTag': 'never',
-            'endTag': 'never',
-            'selfClosingTag': 'never'
-        }]
+            startTag: 'never',
+            endTag: 'never',
+            selfClosingTag: 'never',
+        }],
     },
 };

--- a/src/bulma/Modal.vue
+++ b/src/bulma/Modal.vue
@@ -1,10 +1,9 @@
 <template>
-    <core-modal :show="show"
+    <core-modal :transition-duration="transitionDuration"
         v-bind="$attrs"
         v-on="$listeners">
         <fade slot-scope="{ close }">
-            <div :class="['modal', { 'is-active': show }]"
-                v-if="show">
+            <div class="modal is-active">
                 <div class="modal-background"/>
                 <div class="modal-content">
                     <slot/>
@@ -27,9 +26,9 @@ export default {
     components: { CoreModal, Fade },
 
     props: {
-        show: {
-            type: Boolean,
-            required: true,
+        transitionDuration: {
+            type: Number,
+            default: 500,
         },
     },
 };

--- a/src/bulma/ModalCard.vue
+++ b/src/bulma/ModalCard.vue
@@ -1,10 +1,9 @@
 <template>
-    <core-modal :show="show"
-        :portal="portal"
+    <core-modal :transition-duration="transitionDuration"
+        v-bind="$attrs"
         v-on="$listeners">
         <fade slot-scope="{ close }">
-            <div :class="['modal', { 'is-active': show }]"
-                v-if="show">
+            <div class="modal is-active">
                 <div class="modal-background"/>
                 <div class="modal-card">
                     <header class="modal-card-head">
@@ -35,13 +34,9 @@ export default {
     components: { CoreModal, Fade },
 
     props: {
-        show: {
-            type: Boolean,
-            required: true,
-        },
-        portal: {
-            type: String,
-            default: 'modals',
+        transitionDuration: {
+            type: Number,
+            default: 500,
         },
     },
 };


### PR DESCRIPTION
- drops the need fot the `show` control prop. Now the modal will have to be controlled by `v-if="something"` (which was there anyway in 95% cases). This is breaking and need refactor in all uses
- fixes a bug when the modal was open and the router was used to switch the page, which let the modal hang forever and needed a page reload
- adds a transitionDuration prop that allows using the transition also for the above case
- overall refactor